### PR TITLE
Add basic implementation

### DIFF
--- a/alfos-amazon-s3/build.gradle
+++ b/alfos-amazon-s3/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    implementation project(':alfos-core')
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.11.270'
+}

--- a/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/AmazonS3Storage.kt
+++ b/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/AmazonS3Storage.kt
@@ -1,0 +1,27 @@
+package fr.cvlaminck.alfos.s3
+
+import com.amazonaws.services.s3.AmazonS3
+import fr.cvlaminck.alfos.model.Storage
+import fr.cvlaminck.alfos.model.StorageServiceProvider
+import fr.cvlaminck.alfos.operation.raw.RawStorageOperationsFactory
+import fr.cvlaminck.alfos.s3.mapper.AmazonS3StorageCollectionMapper
+import fr.cvlaminck.alfos.s3.mapper.AmazonS3StorageObjectMapper
+import fr.cvlaminck.alfos.s3.operation.AmazonS3StorageOperationsFactory
+
+class AmazonS3Storage(
+        internal val amazonS3: AmazonS3
+) : Storage {
+
+    internal val collectionMapper = AmazonS3StorageCollectionMapper(this)
+
+    internal val objectMapper = AmazonS3StorageObjectMapper(this)
+
+    override val name: String
+        get() = amazonS3.s3AccountOwner.displayName
+
+    override val provider: StorageServiceProvider
+        get() = AmazonS3StorageProvider
+
+    override val operationsFactory: RawStorageOperationsFactory
+        get() = AmazonS3StorageOperationsFactory(this)
+}

--- a/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/AmazonS3StorageProvider.kt
+++ b/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/AmazonS3StorageProvider.kt
@@ -1,0 +1,16 @@
+package fr.cvlaminck.alfos.s3
+
+import fr.cvlaminck.alfos.model.StorageServiceProvider
+import fr.cvlaminck.alfos.name.NameValidator
+
+object AmazonS3StorageProvider : StorageServiceProvider {
+
+    override val name: String
+        get() = "Amazon S3"
+
+    override val scheme: String
+        get() = TODO("not implemented")
+
+    override val nameValidator: NameValidator
+        get() = TODO("not implemented")
+}

--- a/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/mapper/AmazonS3StorageCollectionMapper.kt
+++ b/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/mapper/AmazonS3StorageCollectionMapper.kt
@@ -1,0 +1,12 @@
+package fr.cvlaminck.alfos.s3.mapper
+
+import com.amazonaws.services.s3.model.Bucket
+import fr.cvlaminck.alfos.model.Storage
+import fr.cvlaminck.alfos.model.StorageCollection
+
+class AmazonS3StorageCollectionMapper(
+        private val storage: Storage
+) {
+    fun map(bucket: Bucket): StorageCollection =
+            StorageCollection(storage = storage, name = bucket.name)
+}

--- a/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/mapper/AmazonS3StorageObjectMapper.kt
+++ b/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/mapper/AmazonS3StorageObjectMapper.kt
@@ -1,0 +1,12 @@
+package fr.cvlaminck.alfos.s3.mapper
+
+import com.amazonaws.services.s3.model.S3ObjectSummary
+import fr.cvlaminck.alfos.model.Storage
+import fr.cvlaminck.alfos.model.StorageObject
+
+class AmazonS3StorageObjectMapper(
+        private val storage: Storage
+) {
+    fun map(s3ObjectSummary: S3ObjectSummary): StorageObject =
+            StorageObject(storage = storage, name = s3ObjectSummary.key, collectionName = s3ObjectSummary.bucketName)
+}

--- a/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/operation/AmazonS3StorageCollectionOperations.kt
+++ b/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/operation/AmazonS3StorageCollectionOperations.kt
@@ -1,0 +1,38 @@
+package fr.cvlaminck.alfos.s3.operation
+
+import com.amazonaws.services.s3.model.ObjectListing
+import com.amazonaws.services.s3.model.S3ObjectSummary
+import fr.cvlaminck.alfos.model.StorageCollection
+import fr.cvlaminck.alfos.model.StorageObject
+import fr.cvlaminck.alfos.operation.raw.RawStorageCollectionOperations
+import fr.cvlaminck.alfos.s3.AmazonS3Storage
+import io.reactivex.Emitter
+import io.reactivex.Flowable
+import io.reactivex.Maybe
+import io.reactivex.Single
+import io.reactivex.functions.BiFunction
+import java.util.concurrent.Callable
+
+class AmazonS3StorageCollectionOperations(
+        private val collectionName: String,
+        private val amazonS3Storage: AmazonS3Storage
+) : RawStorageCollectionOperations {
+
+    override fun getInformation(): Maybe<StorageCollection> =
+            Single.fromCallable { amazonS3Storage.amazonS3.doesBucketExistV2(collectionName) }
+                    .filter { it }
+                    .map { StorageCollection(storage = amazonS3Storage, name = collectionName) }
+
+    override fun listObjects(): Flowable<StorageObject> =
+            Flowable.generate(Callable<ObjectListing> { amazonS3Storage.amazonS3.listObjects(collectionName) }, BiFunction<ObjectListing, Emitter<List<S3ObjectSummary>>, ObjectListing> { listing, emitter ->
+                emitter.onNext(listing.objectSummaries)
+                if (listing.isTruncated) {
+                    return@BiFunction amazonS3Storage.amazonS3.listNextBatchOfObjects(listing)
+                } else {
+                    emitter.onComplete()
+                    return@BiFunction listing
+                }
+            })
+                    .flatMap { Flowable.fromIterable(it) }
+                    .map { amazonS3Storage.objectMapper.map(it) }
+}

--- a/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/operation/AmazonS3StorageObjectOperations.kt
+++ b/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/operation/AmazonS3StorageObjectOperations.kt
@@ -1,0 +1,34 @@
+package fr.cvlaminck.alfos.s3.operation
+
+import fr.cvlaminck.alfos.model.StorageObject
+import fr.cvlaminck.alfos.operation.raw.RawStorageObjectOperations
+import fr.cvlaminck.alfos.s3.AmazonS3Storage
+import io.reactivex.Maybe
+import io.reactivex.Single
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+
+class AmazonS3StorageObjectOperations(
+        private val collectionName: String,
+        private val objectName: String,
+        private val amazonS3Storage: AmazonS3Storage
+) : RawStorageObjectOperations {
+
+    override fun getInformation(): Maybe<StorageObject> =
+            Single.fromCallable { amazonS3Storage.amazonS3.doesObjectExist(collectionName, objectName) }
+                    .filter { it }
+                    .map { StorageObject(storage = amazonS3Storage, collectionName = collectionName, name = objectName) }
+
+    override fun download(): Single<InputStream> =
+            Single.fromCallable { amazonS3Storage.amazonS3.getObject(collectionName, objectName) }
+                    .map { it.objectContent }
+
+    override fun upload(): Single<OutputStream> =
+            Single.fromCallable { PipedInputStream() }
+                    .map {
+                        amazonS3Storage.amazonS3.putObject(collectionName, objectName, it, TODO("must find a way to set metadata"))
+                        PipedOutputStream(it)
+                    }
+}

--- a/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/operation/AmazonS3StorageOperations.kt
+++ b/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/operation/AmazonS3StorageOperations.kt
@@ -1,0 +1,13 @@
+package fr.cvlaminck.alfos.s3.operation
+
+import fr.cvlaminck.alfos.model.StorageCollection
+import fr.cvlaminck.alfos.operation.raw.RawStorageOperations
+import fr.cvlaminck.alfos.s3.AmazonS3Storage
+import io.reactivex.Flowable
+
+class AmazonS3StorageOperations(private val storage: AmazonS3Storage) : RawStorageOperations {
+
+    override fun listCollections(): Flowable<StorageCollection> =
+            Flowable.fromIterable(storage.amazonS3.listBuckets())
+                    .map(storage.collectionMapper::map)
+}

--- a/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/operation/AmazonS3StorageOperationsFactory.kt
+++ b/alfos-amazon-s3/src/main/kotlin/fr/cvlaminck/alfos/s3/operation/AmazonS3StorageOperationsFactory.kt
@@ -1,0 +1,19 @@
+package fr.cvlaminck.alfos.s3.operation
+
+import fr.cvlaminck.alfos.operation.raw.RawStorageCollectionOperations
+import fr.cvlaminck.alfos.operation.raw.RawStorageObjectOperations
+import fr.cvlaminck.alfos.operation.raw.RawStorageOperations
+import fr.cvlaminck.alfos.operation.raw.RawStorageOperationsFactory
+import fr.cvlaminck.alfos.s3.AmazonS3Storage
+
+class AmazonS3StorageOperationsFactory(private val amazonS3Storage: AmazonS3Storage) : RawStorageOperationsFactory {
+
+    override fun getStorageOperations(): RawStorageOperations =
+            AmazonS3StorageOperations(amazonS3Storage)
+
+    override fun getStorageCollectionOperations(collectionName: String): RawStorageCollectionOperations =
+            AmazonS3StorageCollectionOperations(collectionName, amazonS3Storage)
+
+    override fun getStorageObjectOperations(collectionName: String, objectName: String): RawStorageObjectOperations =
+            AmazonS3StorageObjectOperations(collectionName, objectName, amazonS3Storage)
+}

--- a/alfos-amazon-s3/src/test/kotlin/fr/cvlaminck/alfos/s3/AmazonS3Test.kt
+++ b/alfos-amazon-s3/src/test/kotlin/fr/cvlaminck/alfos/s3/AmazonS3Test.kt
@@ -1,0 +1,14 @@
+package fr.cvlaminck.alfos.s3
+
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+
+open class AmazonS3Test {
+
+    val client by lazy {
+        AmazonS3ClientBuilder.defaultClient()
+    }
+
+    val storage by lazy {
+        AmazonS3Storage(client)
+    }
+}

--- a/alfos-amazon-s3/src/test/kotlin/fr/cvlaminck/alfos/s3/operation/AmazonS3StorageCollectionOperationsTest.kt
+++ b/alfos-amazon-s3/src/test/kotlin/fr/cvlaminck/alfos/s3/operation/AmazonS3StorageCollectionOperationsTest.kt
@@ -1,0 +1,31 @@
+package fr.cvlaminck.alfos.s3.operation
+
+import fr.cvlaminck.alfos.s3.AmazonS3Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+@Tag("requires-s3-account")
+internal class AmazonS3StorageCollectionOperationsTest : AmazonS3Test() {
+
+    @Test
+    fun getInformation() {
+        val storageCollection = storage.operationsFactory.getStorageCollectionOperations("read-collection")
+                .getInformation()
+                .blockingGet()
+
+        assertSame(storage, storageCollection.storage)
+        assertEquals("read-collection", storageCollection.name)
+    }
+
+    @Test
+    fun getInformation_nonExisting() {
+        val empty = storage.operationsFactory.getStorageCollectionOperations("non-existing-collection")
+                .getInformation()
+                .isEmpty
+                .blockingGet()
+        assertTrue(empty)
+    }
+}

--- a/alfos-amazon-s3/src/test/kotlin/fr/cvlaminck/alfos/s3/operation/AmazonS3StorageObjectOperationsTest.kt
+++ b/alfos-amazon-s3/src/test/kotlin/fr/cvlaminck/alfos/s3/operation/AmazonS3StorageObjectOperationsTest.kt
@@ -1,0 +1,33 @@
+package fr.cvlaminck.alfos.s3.operation
+
+import fr.cvlaminck.alfos.s3.AmazonS3Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+@Tag("requires-s3-account")
+internal class AmazonS3StorageObjectOperationsTest : AmazonS3Test() {
+
+    @Test
+    fun getInformation() {
+        val storageObject = storage.operationsFactory.getStorageObjectOperations("read-collection", "test")
+                .getInformation()
+                .blockingGet()
+
+        assertSame(storage, storageObject.storage)
+        assertEquals("read-collection", storageObject.collectionName)
+        assertEquals("test", storageObject.name)
+    }
+
+    @Test
+    fun getInformation_notExisting() {
+        val empty = storage.operationsFactory.getStorageObjectOperations("read-collection", "non-existing-object")
+                .getInformation()
+                .isEmpty
+                .blockingGet()
+
+        assertTrue(empty)
+    }
+}

--- a/alfos-amazon-s3/src/test/kotlin/fr/cvlaminck/alfos/s3/operation/AmazonS3StorageOperationsTest.kt
+++ b/alfos-amazon-s3/src/test/kotlin/fr/cvlaminck/alfos/s3/operation/AmazonS3StorageOperationsTest.kt
@@ -1,0 +1,25 @@
+package fr.cvlaminck.alfos.s3.operation
+
+import fr.cvlaminck.alfos.s3.AmazonS3Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+@Tag("requires-s3-account")
+internal class AmazonS3StorageOperationsTest : AmazonS3Test() {
+
+    @Test
+    fun listBuckets() {
+        val storageOperations = storage.operationsFactory.getStorageOperations()
+
+        val collectionNames = storageOperations.listCollections()
+                .map { it.name }
+                .toList()
+                .blockingGet()
+
+        Assertions.assertEquals(
+                listOf("read-collection"),
+                collectionNames
+        )
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,43 +1,54 @@
-plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.2.10" apply false
-}
-
-allprojects {
+buildscript {
     ext {
-        kotlinVersion = "1.2.10"
-        rxJavaVersion = "2.1.5"
-        junitPlatformVersion = "1.0.1"
-        junitJupiterVersion = "5.0.1"
-        mockitoVersion = "2.12.0"
-        kotlinMockitoVersion = "1.5.0"
+        kotlinVersion = '1.2.21'
+        rxJavaVersion = '2.1.9'
+        junitPlatformVersion = '1.0.3'
+        junitJupiterVersion = '5.0.3'
+        mockitoVersion = '2.13.0'
+        kotlinMockitoVersion = '1.5.0'
     }
-}
-
-subprojects {
-    apply plugin: "kotlin"
-
-    group = "fr.cvlaminck.alfos"
 
     repositories {
         jcenter()
     }
 
     dependencies {
-        compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
-
-        compile "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
-
-        testCompile "org.junit.platform:junit-platform-engine:$junitPlatformVersion"
-        testCompile "org.junit.platform:junit-platform-launcher:$junitPlatformVersion"
-        testCompile "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion"
-        testCompile "org.mockito:mockito-core:$mockitoVersion"
-        testCompile "com.nhaarman:mockito-kotlin-kt1.1:$kotlinMockitoVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath "org.junit.platform:junit-platform-gradle-plugin:$junitPlatformVersion"
     }
+}
+
+subprojects {
+    apply plugin: 'java'
+    apply plugin: 'kotlin'
+    apply plugin: 'org.junit.platform.gradle.plugin'
+
+    group = 'fr.cvlaminck.alfos'
+
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+
+        implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
+
+        testImplementation "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
+        testRuntime "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion"
+
+        testImplementation "org.mockito:mockito-core:$mockitoVersion"
+        testImplementation "com.nhaarman:mockito-kotlin-kt1.1:$kotlinMockitoVersion"
+        testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+    }
+
+    sourceCompatibility = JavaVersion.VERSION_1_7
+    targetCompatibility = JavaVersion.VERSION_1_7
 
     compileKotlin {
-        kotlinOptions.jvmTarget = "1.6"
+        kotlinOptions.jvmTarget = JavaVersion.VERSION_1_6
     }
     compileTestKotlin {
-        kotlinOptions.jvmTarget = "1.6"
+        kotlinOptions.jvmTarget = JavaVersion.VERSION_1_6
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 include ":alfos-core"
 include ":alfos-google-cloud-storage"
+include ":alfos-amazon-s3"


### PR DESCRIPTION
I've got a problem with the upload method I need to set the metadata about the uploaded file (at least the size) and it's not possible to do it with the current method signature, except with storing all the data in a buffer before really uploading.

Here is the official documentation :

https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/PutObjectRequest.html#PutObjectRequest-java.lang.String-java.lang.String-java.io.InputStream-com.amazonaws.services.s3.model.ObjectMetadata-

"Content length for the data stream must be specified in the object metadata parameter; Amazon S3 requires it be passed in before the data is uploaded. Failure to specify a content length will cause the entire contents of the input stream to be buffered locally in memory so that the content length can be calculated, which can result in negative performance problems."